### PR TITLE
Fix github streak

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Website: [click here](http://puppet57.xyz)
 
 [![Ashutosh's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=Thepuppetqueen57&theme=react-dark)](https://github.com/ashutosh00710/github-readme-activity-graph)
 
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com?user=thepuppetqueen57&theme=radical)](https://git.io/streak-stats)
+[![GitHub Streak](https://github-readme-streak-stats-eta-lyart.vercel.app?user=thepuppetqueen57&theme=radical)](https://git.io/streak-stats)


### PR DESCRIPTION
Uses a cloned and not so active url that isn't ever down